### PR TITLE
Improve terminal UI and add database isolation for worktrees

### DIFF
--- a/lib/claude_live/application.ex
+++ b/lib/claude_live/application.ex
@@ -7,6 +7,8 @@ defmodule ClaudeLive.Application do
 
   @impl true
   def start(_type, _args) do
+    ClaudeLive.WorktreeDatabase.ensure_database!()
+
     children = [
       ClaudeLiveWeb.Telemetry,
       ClaudeLive.Repo,
@@ -17,23 +19,15 @@ defmodule ClaudeLive.Application do
          Application.fetch_env!(:claude_live, Oban)
        )},
       {Phoenix.PubSub, name: ClaudeLive.PubSub},
-      # Terminal infrastructure
       {Registry, keys: :unique, name: ClaudeLive.Terminal.Registry},
       ClaudeLive.Terminal.Supervisor,
-      # Start a worker by calling: ClaudeLive.Worker.start_link(arg)
-      # {ClaudeLive.Worker, arg},
-      # Start to serve requests, typically the last entry
       ClaudeLiveWeb.Endpoint
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: ClaudeLive.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   @impl true
   def config_change(changed, _new, removed) do
     ClaudeLiveWeb.Endpoint.config_change(changed, removed)

--- a/lib/claude_live/claude/worktree.ex
+++ b/lib/claude_live/claude/worktree.ex
@@ -43,7 +43,8 @@ defmodule ClaudeLive.Claude.Worktree do
 
           case create_git_worktree(worktree.branch, repository.path) do
             {:ok, worktree_path} ->
-              # Update the worktree with the path
+              ClaudeLive.WorktreeDatabase.setup_worktree_database(worktree_path)
+
               updated_worktree =
                 worktree
                 |> Ash.Changeset.for_update(:update, %{path: worktree_path})
@@ -52,7 +53,6 @@ defmodule ClaudeLive.Claude.Worktree do
               {:ok, updated_worktree}
 
             {:error, reason} ->
-              # Return error which will rollback the transaction
               {:error, Ash.Error.Unknown.exception(message: reason)}
           end
         end)

--- a/lib/claude_live/worktree_database.ex
+++ b/lib/claude_live/worktree_database.ex
@@ -1,0 +1,102 @@
+defmodule ClaudeLive.WorktreeDatabase do
+  @moduledoc """
+  Handles database initialization for worktrees.
+  Copies the main database to the worktree if it doesn't exist.
+  """
+
+  require Logger
+
+  @doc """
+  Ensures the worktree has its own database copy.
+  Called during application startup.
+  """
+  def ensure_database! do
+    current_db_path = ClaudeLive.Config.Helpers.database_path(:dev)
+
+    if is_worktree_path?(current_db_path) do
+      Logger.info("Detected worktree environment")
+
+      unless File.exists?(current_db_path) do
+        copy_main_database_to_worktree(current_db_path)
+      else
+        Logger.info("Using existing worktree database: #{current_db_path}")
+      end
+    else
+      Logger.info("Running in main repository")
+    end
+  end
+
+  @doc """
+  Copies database when creating a new worktree.
+  Called after worktree creation in the Ash resource.
+  """
+  def setup_worktree_database(worktree_path) do
+    worktree_db_path = Path.join([worktree_path, "db", "claude_live_dev.db"])
+    ensure_db_directory!(worktree_db_path)
+    copy_main_database_to_worktree(worktree_db_path)
+  end
+
+  defp is_worktree_path?(db_path) do
+    String.contains?(db_path, "/repo/claude_live/") and
+      not String.ends_with?(Path.dirname(Path.dirname(db_path)), "/claude_live")
+  end
+
+  defp copy_main_database_to_worktree(destination_db_path) do
+    main_db_path = get_main_database_path()
+
+    if File.exists?(main_db_path) do
+      Logger.info("Copying main database: #{main_db_path} -> #{destination_db_path}")
+      ensure_db_directory!(destination_db_path)
+      copy_database_files(main_db_path, destination_db_path)
+    else
+      Logger.warning(
+        "No main database found at #{main_db_path}, worktree will start with fresh database"
+      )
+    end
+  end
+
+  defp get_main_database_path do
+    main_repo_path =
+      Path.join([System.user_home!(), "Development", "bradleygolden", "claude_live"])
+
+    Path.join([main_repo_path, "db", "claude_live_dev.db"])
+  end
+
+  defp ensure_db_directory!(db_path) do
+    db_dir = Path.dirname(db_path)
+
+    unless File.exists?(db_dir) do
+      Logger.info("Creating database directory: #{db_dir}")
+      File.mkdir_p!(db_dir)
+    end
+  end
+
+  defp copy_database_files(source, destination) do
+    case File.cp(source, destination) do
+      :ok ->
+        Logger.info("Successfully copied main database file")
+
+        for suffix <- ["-wal", "-shm"] do
+          source_file = source <> suffix
+          dest_file = destination <> suffix
+
+          if File.exists?(source_file) do
+            case File.cp(source_file, dest_file) do
+              :ok ->
+                Logger.debug("Copied #{suffix} file")
+
+              {:error, reason} ->
+                Logger.warning("Could not copy #{suffix} file: #{inspect(reason)}")
+            end
+          end
+        end
+
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to copy database: #{inspect(reason)}")
+        Logger.warning("Worktree will start with a fresh database")
+        :error
+    end
+  end
+end

--- a/lib/claude_live_web/live/terminal_live.ex
+++ b/lib/claude_live_web/live/terminal_live.ex
@@ -234,10 +234,10 @@ defmodule ClaudeLiveWeb.TerminalLive do
       }
     </script>
 
-    <div class="min-h-screen bg-gray-900 p-4">
-      <div class="max-w-6xl mx-auto">
-        <div class="bg-gray-800 rounded-lg shadow-xl overflow-hidden">
-          <div class="bg-gray-700 px-4 py-2 flex items-center justify-between">
+    <div class="h-screen bg-gray-900 flex flex-col">
+      <div class="flex-1 flex flex-col p-2">
+        <div class="bg-gray-800 rounded-lg shadow-xl overflow-hidden flex-1 flex flex-col">
+          <div class="bg-gray-700 px-4 py-2 flex items-center justify-between flex-shrink-0">
             <div class="flex items-center space-x-3">
               <h2 class="text-white font-semibold">Terminal</h2>
               <span class="text-sm text-gray-400">
@@ -270,13 +270,13 @@ defmodule ClaudeLiveWeb.TerminalLive do
             id="terminal-container"
             phx-hook=".TerminalHook"
             phx-update="ignore"
-            class="h-[600px] w-full"
+            class="flex-1 w-full"
           >
             <div id="terminal" class="h-full w-full"></div>
           </div>
         </div>
 
-        <div class="mt-4 flex justify-between">
+        <div class="mt-2 flex justify-between flex-shrink-0">
           <.link
             navigate={~p"/dashboard/#{@worktree.repository_id}"}
             class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 transition"


### PR DESCRIPTION
## Summary
- Update terminal to use full screen height with responsive flexbox layout
- Implement automatic database copying for worktrees on application startup
- Copy main database when creating new worktrees via Ash resource
- Remove fixed 600px height limitation from terminal

## Benefits
- Each worktree now has its own isolated database copy for testing
- Terminal provides better user experience with full viewport usage
- Database changes in worktrees don't affect the main repository

## Test plan
- [x] Terminal displays with full screen height
- [x] Database is automatically copied when starting app in a worktree
- [x] Database is copied when creating new worktrees
- [x] Terminal dependencies (xterm.js) load correctly

🤖 Generated with [Claude Code](https://claude.ai/code)