### PR TITLE
Refactor webhook integration to use Ash.Notifier.PubSub

### DIFF
--- a/lib/claude_live/claude/event.ex
+++ b/lib/claude_live/claude/event.ex
@@ -6,7 +6,8 @@ defmodule ClaudeLive.Claude.Event do
   use Ash.Resource,
     otp_app: :claude_live,
     domain: ClaudeLive.Claude,
-    data_layer: AshSqlite.DataLayer
+    data_layer: AshSqlite.DataLayer,
+    notifiers: [Ash.Notifier.PubSub]
 
   attributes do
     uuid_primary_key :id
@@ -77,6 +78,15 @@ defmodule ClaudeLive.Claude.Event do
       allow_nil? true
       attribute_type :uuid
     end
+  end
+
+  pub_sub do
+    module ClaudeLiveWeb.Endpoint
+    prefix "claude_events"
+
+    publish :from_webhook, ["created"]
+    publish :from_webhook, ["created", :worktree_id]
+    publish :from_webhook, ["created", :event_type]
   end
 
   actions do


### PR DESCRIPTION
## Summary
• Replace manual broadcasting with Ash's built-in PubSub notifier for cleaner code
• Add Claude notification status indicator to terminal interface 
• Implement blue pulsing dot when Claude Code sends notifications

## Technical Changes
• **Event Resource**: Add `Ash.Notifier.PubSub` with flexible topic patterns
• **Webhook Controller**: Remove manual broadcasting logic, let Ash handle it
• **Terminal LiveView**: Subscribe to Ash notifications and handle status updates
• **UI Enhancement**: Blue notification indicator with click-to-dismiss functionality

## Test Plan
- [x] Webhook events properly broadcast via Ash PubSub
- [x] Terminal live view receives and handles notifications
- [x] Status indicator shows blue when notifications present
- [x] Users can dismiss notifications by clicking indicator

🤖 Generated with [Claude Code](https://claude.ai/code)